### PR TITLE
Remove slow vs tool install and reset

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,12 +57,10 @@ jobs:
 
       - name: 📦 artifact
         uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
-          name: tests-${{ github.run_number }}
-          path: |
-            ./out
-            ./**/*.dmp
+          name: dumps-${{ github.run_number }}
+          path: ./**/*.dmp
 
       - name: 🚀 sleet
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,19 +52,8 @@ jobs:
         if: always()
         run: dotnet pack --no-build -m:1
 
-      - name: 🛠 vs
-        run: | 
-          dotnet tool install -g dotnet-vs
-          vs /NoSplash /ResetSettings General /Command "File.Exit"
-          wait-process -name 'devenv'
-          vs
-
       - name: 🧪 test
         uses: ./.github/workflows/test
-
-      - name: ❎ vs
-        if: always()
-        run: vs kill all
 
       - name: 📦 artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
         run: dotnet pack --no-build -m:1
 
       - name: 🧪 test
+        timeout-minutes: 15
         uses: ./.github/workflows/test
 
       - name: 📦 artifact


### PR DESCRIPTION
This is no longer necessary now that we figured out the remaining discovery and runtime bugs in xunit.vsix itself, since the IDE reset is done automatically by the test framework.