### PR TITLE
Don't request DTE via COM since it can hang VS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,9 @@ jobs:
         if: failure()
         with:
           name: dumps-${{ github.run_number }}
-          path: ./**/*.dmp
+          path: |
+            ./**/*.dmp
+            ./**/*.log
 
       - name: 🚀 sleet
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,12 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: ⚙ msbuild
+      - name: ≥ msbuild
+        id: msbuild
         uses: microsoft/setup-msbuild@v1.1
+
+      - name: ≥ defaults
+        run: echo $((gi '${{ steps.msbuild.outputs.msbuildPath }}\..\..\..\Common7\IDE').FullName.TrimEnd('\')) >> $env:GITHUB_PATH
 
       - name: ≥ version
         if: github.event_name == 'release'
@@ -49,6 +53,15 @@ jobs:
         if: always()
         run: dotnet pack --no-build -m:1
 
+      - name: 🛠 vs
+        run: | 
+          # Forces a reset, full MEF refresh and exits
+          devenv .\Xunit.Vsix.sln /NoSplash /ResetSettings General /Command "File.Exit"
+          wait-process -name 'devenv'
+          # Same, for the experimental instance
+          devenv .\Xunit.Vsix.sln /RootSuffix Exp /NoSplash /ResetSettings General /Command "File.Exit"
+          wait-process -name 'devenv'
+        
       - name: 🧪 test
         timeout-minutes: 10
         uses: ./.github/workflows/test

--- a/src/Xunit.Vsix/IVsRemoteRunner.cs
+++ b/src/Xunit.Vsix/IVsRemoteRunner.cs
@@ -5,6 +5,8 @@ namespace Xunit
 {
     interface IVsRemoteRunner : IDisposable
     {
+        void EnsureInitialized();
+
         string[][] GetEnvironment();
 
         void Ping();

--- a/src/Xunit.Vsix/RunningObjects.cs
+++ b/src/Xunit.Vsix/RunningObjects.cs
@@ -80,7 +80,7 @@ namespace Xunit
             if (moniker == null)
                 return null;
 
-            if (ErrorHandler.Succeeded(NativeMethods.GetRunningObjectTable(0, out var rdt)) && 
+            if (ErrorHandler.Succeeded(NativeMethods.GetRunningObjectTable(0, out var rdt)) &&
                 ErrorHandler.Succeeded(rdt.GetObject(moniker, out var comObject)))
                 return comObject;
 

--- a/src/Xunit.Vsix/VsClient.cs
+++ b/src/Xunit.Vsix/VsClient.cs
@@ -314,7 +314,7 @@ namespace Xunit
             // Wait for DTE, but don't retrieve it, since that can cause a hang.
             while (start.ElapsedMilliseconds < timeout && !(dteFound = RunningObjects.FindDTE(version, Process.Id)))
                 Thread.Sleep(100);
-            
+
             if (!dteFound)
             {
                 s_tracer.TraceEvent(TraceEventType.Error, 0, Strings.VsClient.FailedToStart(_visualStudioVersion, _rootSuffix));

--- a/src/Xunit.Vsix/VsClient.cs
+++ b/src/Xunit.Vsix/VsClient.cs
@@ -317,7 +317,7 @@ namespace Xunit
             
             if (!dteFound)
             {
-                s_tracer.TraceEvent(TraceEventType.Error, 0, Strings.VsClient.FailedToInject(Process.Id));
+                s_tracer.TraceEvent(TraceEventType.Error, 0, Strings.VsClient.FailedToStart(_visualStudioVersion, _rootSuffix));
                 return false;
             }
 

--- a/src/Xunit.Vsix/VsClient.cs
+++ b/src/Xunit.Vsix/VsClient.cs
@@ -209,6 +209,8 @@ namespace Xunit
             Constants.Tracer.TraceEvent(TraceEventType.Verbose, 0, Strings.VsClient.RemoteEnvVars(string.Join(Environment.NewLine,
                 remoteVars.Select(x => "    " + x[0] + "=" + x[1]))));
 
+            _runner.EnsureInitialized();
+
             return true;
         }
 

--- a/src/Xunit.Vsix/VsRemoteRunner.cs
+++ b/src/Xunit.Vsix/VsRemoteRunner.cs
@@ -28,7 +28,7 @@ namespace Xunit
     {
         string _pipeName;
         IChannel _channel;
-        JoinableTaskFactory _jtf; 
+        JoinableTaskFactory _jtf;
 
         Dictionary<Type, object> _assemblyFixtureMappings = new Dictionary<Type, object>();
         Dictionary<Type, object> _collectionFixtureMappings = new Dictionary<Type, object>();
@@ -47,7 +47,7 @@ namespace Xunit
                 return;
 
             var ev = new ManualResetEventSlim();
-            
+
             var task = ThreadHelper.JoinableTaskFactory.RunAsync(async () =>
             {
                 var shell = await ServiceProvider.GetGlobalServiceAsync<SVsShell, IVsShell>();
@@ -68,7 +68,7 @@ namespace Xunit
             });
 
             ev.Wait();
-            
+
             _jtf = ThreadHelper.JoinableTaskFactory;
         }
 

--- a/src/Xunit.Vsix/VsixRunnerAttribute.cs
+++ b/src/Xunit.Vsix/VsixRunnerAttribute.cs
@@ -39,6 +39,12 @@ namespace Xunit
         public int StartupTimeout { get; set; }
 
         /// <summary>
+        /// Wait time in milliseconds to wait for Visual Studio to warm up 
+        /// before injecting into the .NET runtime in it.
+        /// </summary>
+        public int WarmupMilliseconds { get; set; }
+
+        /// <summary>
         /// Specifies the tracing level for runner diagnostics.
         /// </summary>
         public SourceLevels TraceLevel { get; set; }

--- a/src/Xunit.Vsix/VsixRunnerSettings.cs
+++ b/src/Xunit.Vsix/VsixRunnerSettings.cs
@@ -4,7 +4,7 @@
     {
         public VsixRunnerSettings(int? debuggerAttachRetries = null, int? remoteConnectionRetries = null,
             int? processStartRetries = null, int? retrySleepInterval = null,
-            int? startupTimeoutSeconds = null, 
+            int? startupTimeoutSeconds = null,
             int? warnupSeconds = null)
         {
             DebuggerAttachRetries = debuggerAttachRetries ?? 5;

--- a/src/Xunit.Vsix/VsixRunnerSettings.cs
+++ b/src/Xunit.Vsix/VsixRunnerSettings.cs
@@ -4,13 +4,15 @@
     {
         public VsixRunnerSettings(int? debuggerAttachRetries = null, int? remoteConnectionRetries = null,
             int? processStartRetries = null, int? retrySleepInterval = null,
-            int? startupTimeout = null)
+            int? startupTimeoutSeconds = null, 
+            int? warnupSeconds = null)
         {
             DebuggerAttachRetries = debuggerAttachRetries ?? 5;
             RemoteConnectionRetries = remoteConnectionRetries ?? 2;
             ProcessStartRetries = processStartRetries ?? 1;
             RetrySleepInterval = retrySleepInterval ?? 200;
-            StartupTimeout = startupTimeout ?? 300;
+            StartupTimeoutSeconds = startupTimeoutSeconds ?? 30;
+            WarmupSeconds = warnupSeconds ?? 10;
         }
 
         /// <summary>
@@ -37,9 +39,15 @@
         public int RetrySleepInterval { get; private set; }
 
         /// <summary>
-        /// The timeout in seconds to wait for Visual Studio to
-        /// start and initialize its DTE automation model.
+        /// The timeout in seconds to for the test runner to successfully 
+        /// inject itself into the Visual Studio .NET runtime.
         /// </summary>
-        public int StartupTimeout { get; private set; }
+        public int StartupTimeoutSeconds { get; private set; }
+
+        /// <summary>
+        /// Wait time in seconds for Visual Studio to warm up 
+        /// before injecting into the .NET runtime in it.
+        /// </summary>
+        public int WarmupSeconds { get; private set; }
     }
 }

--- a/src/Xunit.Vsix/VsixRunnerSettings.cs
+++ b/src/Xunit.Vsix/VsixRunnerSettings.cs
@@ -9,8 +9,8 @@
         {
             DebuggerAttachRetries = debuggerAttachRetries ?? 5;
             RemoteConnectionRetries = remoteConnectionRetries ?? 2;
-            ProcessStartRetries = processStartRetries ?? 1;
-            RetrySleepInterval = retrySleepInterval ?? 200;
+            ProcessStartRetries = processStartRetries ?? 3;
+            RetrySleepInterval = retrySleepInterval ?? 500;
             StartupTimeoutSeconds = startupTimeoutSeconds ?? 30;
             WarmupSeconds = warnupSeconds ?? 10;
         }
@@ -27,7 +27,7 @@
         public int RemoteConnectionRetries { get; private set; }
 
         /// <summary>
-        /// Number of retries to start VS and connect to its DTE service.
+        /// Number of retries to start VS and ensure proper initialization.
         /// </summary>
         public int ProcessStartRetries { get; private set; }
 

--- a/src/Xunit.Vsix/VsixTestCollection.cs
+++ b/src/Xunit.Vsix/VsixTestCollection.cs
@@ -26,7 +26,8 @@ namespace Xunit
                     settingsAttribute.GetInitializedArgument<int?>(nameof(VsixRunnerSettings.RemoteConnectionRetries)),
                     settingsAttribute.GetInitializedArgument<int?>(nameof(VsixRunnerSettings.ProcessStartRetries)),
                     settingsAttribute.GetInitializedArgument<int?>(nameof(VsixRunnerSettings.RetrySleepInterval)),
-                    settingsAttribute.GetInitializedArgument<int?>(nameof(VsixRunnerSettings.StartupTimeout)));
+                    settingsAttribute.GetInitializedArgument<int?>(nameof(VsixRunnerSettings.StartupTimeoutSeconds)),
+                    settingsAttribute.GetInitializedArgument<int?>(nameof(VsixRunnerSettings.WarmupSeconds)));
         }
 
         public string VisualStudioVersion { get; }

--- a/src/Xunit.Vsix/build/xunit.runner.json
+++ b/src/Xunit.Vsix/build/xunit.runner.json
@@ -1,5 +1,3 @@
 ﻿{
-  "shadowCopy": false,
-  "diagnosticMessages": true,
-  "internalDiagnosticMessages": true
+  "shadowCopy": false
 }


### PR DESCRIPTION
We were forcedly attempting to retrieve the DTE from the just-started devenv process, and this was another cause of hangs. Since the .NET injection itself doesn't depend on anything VS-specific, just do a quick warmup wait instead before just injecting the process, since the first test run will already do the VS-friendly wait for devenv to fully initialize.