### PR TITLE
While debugging a test, timeouts should be disabled

### DIFF
--- a/src/Xunit.Vsix/VsClient.cs
+++ b/src/Xunit.Vsix/VsClient.cs
@@ -284,6 +284,10 @@ namespace Xunit
             // Allow debugging the tests via CLI
             info.EnvironmentVariables[Constants.DebugRemoteEnvironmentVariable] = Environment.GetEnvironmentVariable(Constants.DebugRemoteEnvironmentVariable);
 
+            // If debugger is already attached, propagate the no-timeout flag to the remote process
+            if (Debugger.IsAttached)
+                info.EnvironmentVariables[Constants.DisableTimeoutEnvironmentVariable] = "true";
+
             // Propagate profiling values to support OpenCover or any third party profiler
             // already attached to the current process.
             PropagateProfilingVariables(info);
@@ -448,7 +452,7 @@ namespace Xunit
             return path;
         }
 
-        IEnumerable<Interop.DTE> GetAllDtes()
+        IEnumerable<EnvDTE80.DTE2> GetAllDtes()
         {
             IRunningObjectTable table;
             IEnumMoniker moniker;
@@ -471,7 +475,9 @@ namespace Xunit
                     {
                         object comObject;
                         table.GetObject(rgelt[0], out comObject);
-                        yield return (Interop.DTE)comObject;
+#pragma warning disable VSTHRD010 // Invoke single-threaded types on Main thread
+                        yield return (EnvDTE80.DTE2)comObject;
+#pragma warning restore VSTHRD010 // Invoke single-threaded types on Main thread
                     }
                 }
             }


### PR DESCRIPTION
Even though the remote process will detect the attached debugger (since we attach if possible), it's safer to just propagate the disabling of timeouts entirely, just in case the debugger attaching fails (and users resort to Debugger.Break or Debugger.Launch).

Fixes #57